### PR TITLE
Implement `conj` for `AbstractArray`s of RF's

### DIFF
--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -7,6 +7,11 @@ convert{T,S,U1,V1,U2,V2}(::Type{RationalFunction{Val{T},Val{S},U1,V1}},
   RationalFunction(convert(Poly{U1}, r.num), convert(Poly{V1}, r.den), Val{S})
 convert{T,S,U,V}(::Type{RationalFunction{Val{T},Val{S},U,V}},
   r::RationalFunction{Val{T},Val{S},U,V}) = r
+# Conversion between :conj and :nonc RF's (related to #2)
+convert{T,S1,S2,U1,V1,U2,V2}(::Type{RationalFunction{Val{T},Val{S1},U1,V1}},
+  r::RationalFunction{Val{T},Val{S2},U2,V2}) =
+  RationalFunction(convert(Poly{U1}, conj(r.num)), convert(Poly{V1}, conj(r.den)),
+  Val{S1})
 
 # Relation with numbers
 promote_rule{T,S,U,V,Y<:Number}(::Type{RationalFunction{Val{T},Val{S},U,V}}, ::Type{Y}) =

--- a/src/methods.jl
+++ b/src/methods.jl
@@ -206,6 +206,8 @@ function conj{T,S}(r::RationalFunction{Val{T},Val{S}})
   RationalFunction(Poly(conj(copy(numcoeff)), T), Poly(conj(copy(dencoeff)), T),
     Val{ifelse(S == :conj, :notc, :conj)})
 end
+# Related to #2. This is the solution in Julia v0.6 in `arraymath.jl`
+conj{T,S,U,V}(m::AbstractArray{RationalFunction{Val{T},Val{S},U,V}}) = map(conj, m)
 
 ## Derivative
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -141,6 +141,19 @@ r2 = conj(r1)
 @test num(r1) == conj(num(r2))
 @test den(r1) == conj(den(r2))
 
+# test related to #2
+m1 = fill(r1,1,1) # [r1]
+m2 = fill(r2,1,1) # [conj(r1)]
+m3 = conj(m1)     # [conj(r1)]
+
+@test m2 == m3
+
+r3 = convert(typeof(r1), r1)
+r4 = convert(typeof(r2), r1)
+
+@test r1 == r3
+@test r2 == r4
+
 ## Derivative and reduction
 ### p1 = (x-1)(x-1)
 ### p2 = (x-1)(x-2)(x-3)


### PR DESCRIPTION
### Changes

Implemented `conj` manually similar to that of Julia v0.6. In the new version, it is implemented using `broadcast`. Here, I have chosen `map`.

**Note.** There was no need to implement this except for backwards compatibility purposes.

Cc: @neveritt

### Reference

Fixes #2.