### PR TITLE
Change promote rules for `Number`s and `Poly`s

### DIFF
--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -10,13 +10,13 @@ convert{T,S,U,V}(::Type{RationalFunction{Val{T},Val{S},U,V}},
 
 # Relation with numbers
 promote_rule{T,S,U,V,Y<:Number}(::Type{RationalFunction{Val{T},Val{S},U,V}}, ::Type{Y}) =
-  RationalFunction{Val{T},Val{S},promote_type(U,Y),V}
+  RationalFunction{Val{T},Val{S},promote_type(U,Y),promote_type(V,Y)}
 convert{T,S,U,V}(::Type{RationalFunction{Val{T},Val{S},U,V}}, n::Number) =
   RationalFunction(Poly(U[n], T), Poly([one(V)], T), Val{S})
 
 # Relation with polynomials
 promote_rule{T,S,U,V,Y<:Number}(::Type{RationalFunction{Val{T},Val{S},U,V}},
-  ::Type{Poly{Y}}) = RationalFunction{Val{T},Val{S},promote_type(U,Y),V}
+  ::Type{Poly{Y}}) = RationalFunction{Val{T},Val{S},promote_type(U,Y),promote_type(V,Y)}
 function convert{T,S,U,V}(::Type{RationalFunction{Val{T},Val{S},U,V}}, p::Poly)
   newpoly = convert(Poly{U}, p)
   RationalFunction(newpoly, Poly([one(V)], T), Val{S})

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -45,11 +45,11 @@ p3 = poly(v3)
   RationalFunction{Val{:x}, Val{:notc}, promote_type(eltype(v1), eltype(v2)),
     promote_type(eltype(v1), eltype(v2))}
 @test eltype([RationalFunction(px_, qx), 1.])                        ==
-  RationalFunction{Val{px_.var}, Val{:notc}, promote_type(eltype(px_), Float64),
-    eltype(qx)}
+  RationalFunction{Val{px_.var}, Val{:notc}, promote_type(eltype(px_), typeof(1.)),
+    promote_type(eltype(qx), typeof(1.))}
 @test eltype([RationalFunction(px_, qx, Val{:conj}), p3])            ==
   RationalFunction{Val{px_.var}, Val{:conj}, promote_type(eltype(px_), eltype(p3)),
-    eltype(qx)}
+    promote_type(eltype(qx), eltype(p3))}
 
 @test_throws DomainError [RationalFunction(px_, qx), ps]
 


### PR DESCRIPTION
### Changes

Changed the promote rules for `Number`s and `Poly`s for consistency with the constructor `RationalFunction(num[, den = one(num)])`.

### Reference

Fixes #4.
